### PR TITLE
Demo :has selector (partial browser support)

### DIFF
--- a/_extensions/close-read/custom.scss
+++ b/_extensions/close-read/custom.scss
@@ -38,9 +38,17 @@
     // transition through (based on reveal's .r-stack)
     .body_col_stack {
       display: grid;
-      
+
+      // stackable elements
+      // (note some inline elements come wrapped in empty <p>s)      
       [data-cr],
       .cr-sticky {
+        grid-area: 1 / 1;
+        margin: auto;
+        opacity: 0.5;     // lowering opacity for debug purposes
+      }
+
+      & > p:not(.cr-sticky):has(.cr-sticky) {
         grid-area: 1 / 1;
         margin: auto;
         opacity: 0.5;     // lowering opacity for debug purposes


### PR DESCRIPTION
(Not to be merged; just for demo purposes)

Shows use of `:has()` CSS selector to target something based on its descendents.