### PR TITLE
WIP transition works, except blue desktop

### DIFF
--- a/_extensions/close-read/close-read.lua
+++ b/_extensions/close-read/close-read.lua
@@ -45,9 +45,11 @@ end
 function shift_class_to_block(block)
   
   if pandoc.utils.type(block.content) == "Inlines" then
-    for _, inline in pairs(block.content) do
+    for i, inline in pairs(block.content) do
       if inline.attr ~= nil then
         if inline.classes:includes("cr-sticky") then
+          -- removes cr-sticky from inline element
+          block.content[i].classes:remove(find_in_arr(block.content[i].classes, "cr-sticky"))
           -- wraps block in Div with class cr-sticky (and converts Para to Plain)
           block = pandoc.Div(block.content, pandoc.Attr("", {"cr-sticky"}, {}))
         end
@@ -87,6 +89,15 @@ function is_sticky(block)
   end
 
   return sticky_block_class or sticky_block_attribute or sticky_inline_class
+end
+
+-- utility function
+function find_in_arr(arr, value)
+    for i, v in pairs(arr) do
+        if v == value then
+            return i
+        end
+    end
 end
 
 

--- a/_extensions/close-read/custom.scss
+++ b/_extensions/close-read/custom.scss
@@ -38,13 +38,25 @@
     // transition through (based on reveal's .r-stack)
     .sticky_col_stack {
       display: grid;
-      
+
       [data-cr],
       .cr-sticky {
         grid-area: 1 / 1;
         margin: auto;
-        opacity: 0.5;     // lowering opacity for debug purposes
+        // opacity: 0.5;     // lowering opacity for debug purposes
+
+        // to be overruled when it is the active element
+        opacity: 0;
+        transition: opacity linear 0.5s;
+
+        
       }
+
+      // show the last .scrolledby
+      :nth-last-child(1 of .cr-scrolledby) {
+        opacity: 1;
+      }
+      
     }
   }
 }

--- a/_extensions/close-read/scroller-init.js
+++ b/_extensions/close-read/scroller-init.js
@@ -8,15 +8,62 @@
 
 console.log("Initialising scrollers...")
 
-// const scroller = scrollama();
+document.addEventListener("DOMContentLoaded", () => {
+   const scroller = scrollama();
+   
+   scroller
+     .setup({
+       step: ".cr-step",
+     })
+     .onStepEnter((response) => {
+       // { element, index, direction }
 
-// scroller
-//   .setup({
-//     step: ".step",
-//   })
-//   .onStepEnter((response) => {
-//     // { element, index, direction }
-//   })
-//   .onStepExit((response) => {
-//     // { element, index, direction }
-//   });
+      console.log("Element " + response.index +
+         " scrolled IN " + response.direction + ": " +
+         response.element.textContent)
+      // console.log(response.element)
+
+      /* unfortunately i'm noticing that scrollama sometimes misses events when
+         scrolling fast. so all sticky elements need to be touched when we're
+         receiving an update */
+      
+      if (response.direction == "down") {
+         let allStickies = Array.from(
+            document.querySelectorAll(".cr-sticky, [data-cr=\"sticky\"]"));
+         let pastStickies = allStickies.slice(0, response.index + 1);
+         let futureStickies = allStickies.slice(response.index + 1);
+         
+         console.log(pastStickies.length + " back from here; " +
+            futureStickies.length + " ahead")
+   
+         pastStickies.forEach(e => e.classList.add("cr-scrolledby"));
+         futureStickies.forEach(e => e.classList.remove("cr-scrolledby"));
+         
+      }
+
+      
+
+     })
+     .onStepExit((response) => {
+       // { element, index, direction }
+       console.log("Element " + response.index +
+         " scrolled OUT " + response.direction + ": " +
+         response.element.textContent)
+      //  console.log(response.element)
+
+       if (response.direction == "up") {
+         // do the same as above, but response.index - 1
+         let allStickies = Array.from(
+            document.querySelectorAll(".cr-sticky, [data-cr=\"sticky\"]"));
+         let pastStickies = allStickies.slice(0, response.index);
+         let futureStickies = allStickies.slice(response.index);
+         
+         console.log(pastStickies.length + " back from here; " +
+            futureStickies.length + " ahead")
+   
+         pastStickies.forEach(e => e.classList.add("cr-scrolledby"));
+         futureStickies.forEach(e => e.classList.remove("cr-scrolledby"));
+       }
+
+     });
+ });

--- a/_extensions/close-read/scroller-init.js
+++ b/_extensions/close-read/scroller-init.js
@@ -9,6 +9,11 @@
 console.log("Initialising scrollers...")
 
 document.addEventListener("DOMContentLoaded", () => {
+   
+   // TODO - scroller events don't trigger if an elements starts
+   // visible on page load, so we need to initialise the .scrolledby
+   // classes on page load too
+   
    const scroller = scrollama();
    
    scroller

--- a/_extensions/close-read/scroller-init.js
+++ b/_extensions/close-read/scroller-init.js
@@ -14,20 +14,22 @@ document.addEventListener("DOMContentLoaded", () => {
    scroller
      .setup({
        step: ".cr-step",
+       offset: 0.4
      })
      .onStepEnter((response) => {
        // { element, index, direction }
 
-      console.log("Element " + response.index +
-         " scrolled IN " + response.direction + ": " +
-         response.element.textContent)
-      // console.log(response.element)
+       // console.log(response.element)
+       
+       /* unfortunately i'm noticing that scrollama sometimes misses events when
+       scrolling fast. so all sticky elements need to be touched when we're
+       receiving an update */
+       
+       if (response.direction == "down") {
+         console.log("Element " + response.index +
+            " scrolled IN " + response.direction + ": " +
+            response.element.textContent)
 
-      /* unfortunately i'm noticing that scrollama sometimes misses events when
-         scrolling fast. so all sticky elements need to be touched when we're
-         receiving an update */
-      
-      if (response.direction == "down") {
          let allStickies = Array.from(
             document.querySelectorAll(".cr-sticky, [data-cr=\"sticky\"]"));
          let pastStickies = allStickies.slice(0, response.index + 1);
@@ -35,6 +37,8 @@ document.addEventListener("DOMContentLoaded", () => {
          
          console.log(pastStickies.length + " back from here; " +
             futureStickies.length + " ahead")
+
+         console.log("Latest element visible is:", pastStickies[pastStickies.length - 1])
    
          pastStickies.forEach(e => e.classList.add("cr-scrolledby"));
          futureStickies.forEach(e => e.classList.remove("cr-scrolledby"));
@@ -46,13 +50,13 @@ document.addEventListener("DOMContentLoaded", () => {
      })
      .onStepExit((response) => {
        // { element, index, direction }
-       console.log("Element " + response.index +
-         " scrolled OUT " + response.direction + ": " +
-         response.element.textContent)
-      //  console.log(response.element)
-
+       //  console.log(response.element)
+       
        if (response.direction == "up") {
-         // do the same as above, but response.index - 1
+         console.log("Element " + response.index +
+           " scrolled OUT " + response.direction + ": " +
+           response.element.textContent)
+          // do the same as above, but response.index - 1
          let allStickies = Array.from(
             document.querySelectorAll(".cr-sticky, [data-cr=\"sticky\"]"));
          let pastStickies = allStickies.slice(0, response.index);
@@ -60,6 +64,8 @@ document.addEventListener("DOMContentLoaded", () => {
          
          console.log(pastStickies.length + " back from here; " +
             futureStickies.length + " ahead")
+         
+         console.log("Latest element visible is:", pastStickies[pastStickies.length - 1])
    
          pastStickies.forEach(e => e.classList.add("cr-scrolledby"));
          futureStickies.forEach(e => e.classList.remove("cr-scrolledby"));

--- a/sidebar-cr-multiple-block-types.qmd
+++ b/sidebar-cr-multiple-block-types.qmd
@@ -10,27 +10,37 @@ filters:
   - _extensions/close-read/close-read.lua
 ---
 
-:::{.cr-sidebar}
+::::{.cr-sidebar}
 
 # Test other sticky block types
 
 First paragraph.
 
 ::: {}
-This is a para nested in a div.
+This is a para nested in a div. These two first bits don't trigger anything...
 :::
 
-This is an image with the sticky tag on the div.
+[This is an image with the sticky tag on the div.]{.cr-step}
 
 :::{.cr-sticky}
 ![](pink-desktop.png)
 :::
 
-This is an image with the sticky tag on Image itself
+:::{.cr-step}
+This is an image with the sticky tag on Image itself.
+:::
 
 ![](blue-desktop.png){.cr-sticky}
 
-This is a scatterplot.
+::::
+
+::::{style="background-color: #dddddd"}
+Here's a little non-scrolling interlude before our next scrolly section!
+::::
+
+::::{.cr-sidebar}
+
+[This is a scatterplot.]{.cr-step}
 
 ```{r}
 #| echo: false
@@ -39,7 +49,7 @@ This is a scatterplot.
 plot(mtcars$mpg, mtcars$dist)
 ```
 
-This is a histogram.
+[This is a histogram.]{.cr-step}
 
 ```{r}
 #| echo: true
@@ -48,14 +58,14 @@ This is a histogram.
 hist(mtcars$mpg)
 ```
 
-This is a list (a block element).
+[This is a list (a block element).]{.cr-step}
 
 :::{.cr-sticky}
 1. Apple
 2. Banana
 :::
 
-This is display math.
+[This is display math.]{.cr-step}
 
 ::: {.cr-sticky}
 
@@ -68,13 +78,13 @@ $$
 
 :::
 
-This is a Para featuring a poem.
+[This is a Para featuring a poem.]{.cr-step}
 
 ::: {.cr-sticky}
 One hen, two ducks ...
 :::
 
-This is a mermaid diagram
+[This is a mermaid diagram]{.cr-step}
 
 ```{mermaid}
 %%| cr: sticky
@@ -85,7 +95,7 @@ flowchart LR
   C --> E[Result two]
 ```
 
-This is a graphviz diagram
+[This is a graphviz diagram]{.cr-step}
 
 ```{dot}
 //| cr: sticky

--- a/sidebar-cr-multiple-block-types.qmd
+++ b/sidebar-cr-multiple-block-types.qmd
@@ -34,7 +34,7 @@ This is an image with the sticky tag on Image itself.
 
 ::::
 
-::::{style="background-color: #dddddd"}
+::::{.column-screen-inset style="background-color: #dddddd; padding: 50px;"}
 Here's a little non-scrolling interlude before our next scrolly section!
 ::::
 


### PR DESCRIPTION
First test of actual Scrollama transitions.

This works, with some caveats:

1. The blue desktop one doesn't currently work because both the wrapper <p> and the contents <img> have .cr-sticky.

2. The double counting of blue desktop is throwing off the count of subsequent sticky elements.

I think both these problems can be solved if the Lua script removes the class from the <img> when it moves it to the wrapper <p>. But,

3. Events sometimes don't trigger properly at narrower widths. I _think_ this is related to the visibility of the displayed elements (although I'm not sure why that would be the case). Hopefully building a proper mobile layout will ameliorate this problem!

Thst said, it broadly works as expected! 🥳
