### PR TITLE
Wrap steps + mobile overlay view

### DIFF
--- a/_extensions/closeread/custom.scss
+++ b/_extensions/closeread/custom.scss
@@ -62,8 +62,39 @@
   }
 }
 
+/* mobile (overlay) view */
+
+@include media-breakpoint-down(lg) { 
+  .columns.cr-sidebar {
+    flex-direction: column-reverse;
+
+    .column.sidebar_col {
+      width: 100% !important;
+      padding-inline: 7.5%;
+      align-self: center;
+      z-index: 1;
+
+
+      /* wip - this is supposed to target our narrative blocks to make them readable over the sticky content, but since non-step narrative blocks (ie. bare content) also gets spaced, this breaks the spacing. we may need to wrap other blocks too, not just the steps. */
+      & > *:not(section, .cr-crossfade),
+      section > *:not(.cr-crossfade),
+      .cr-crossfade > * {
+        padding: 10px;
+        background-color: #fafafabb;
+        max-width: 90%;
+        margin-inline: auto;
+      }
+    }
+
+    .column.sticky_col {
+      width: 100% !important;
+      align-self: center;
+    }
+  }
+ }
+
 // debug
 .cr-debug .cr-crossfade {
-  background-color: yellow;
+  background-color: #ffff0099;
   border: 1px solid orange;
 }

--- a/_extensions/closeread/custom.scss
+++ b/_extensions/closeread/custom.scss
@@ -21,12 +21,10 @@
   // vertical space around sidebar elements
   // (markdown headings create sections of content that we need to account for)
   .column.sidebar_col {
-    & > *,
-    section > * {
-      // margin-block: 10svh;
-      // border-block-width: 200px;
-      // border-block-color: yellow; 
-      padding-top: 40svh;
+    & > *:not(section),
+    section > * { 
+      padding-block-start: 20svh;
+      padding-block-end: 20svh;
       vertical-align: middle;
     }
   }
@@ -62,4 +60,10 @@
       
     }
   }
+}
+
+// debug
+.cr-debug .cr-crossfade {
+  background-color: yellow;
+  border: 1px solid orange;
 }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -15,7 +15,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const debugMode =
     document
       .querySelector("meta[cr-debug-mode]")?.getAttribute("cr-debug-mode")
-        === true;
+        === "true";
+
+  // if debugging, add .cr-debug to .cr-section divs
+  // so we can add some of our own css
+  if (debugMode) {
+    document.querySelectorAll(".cr-sidebar").forEach(
+      node => node.classList.add("cr-debug")
+    )
+  }
 
   // define an ojs variable if the connector module is available
   const ojsModule = window._ojs?.ojsConnector?.mainModule

--- a/demo-block-types.qmd
+++ b/demo-block-types.qmd
@@ -28,7 +28,7 @@ This is an image with the sticky tag on Image itself.
 I've replaced its margin with some padding to demonstrate that you can give it a larger "surface" area on which to trigger scroll events.
 :::
 
-![This is a caption](blue-desktop.png){cr-id="blue"}
+![](blue-desktop.png){cr-id="blue"}
 
 ::::
 

--- a/sidebar-cr-multiple-block-types.qmd
+++ b/sidebar-cr-multiple-block-types.qmd
@@ -14,14 +14,18 @@ First paragraph.
 This is a para nested in a div. These two first bits don't trigger anything...
 :::
 
-[This is an image with the sticky tag on the div.]{.cr-crossfade cr-to="pink"}
+:::{.cr-crossfade cr-to="pink"}
+This is an image with the sticky tag on the div.
+:::
 
 :::{cr-id="pink"}
 ![](pink-desktop.png)
 :::
 
-:::{.cr-crossfade cr-from="pink" cr-to="blue" style="margin-block: 0; padding-block: 20svh; background-color: pink;"}
-This is an image with the sticky tag on Image itself. I've replaced its margin with some padding to demonstrate that you can give it a larger "surface" area on which to trigger scroll events.
+:::{.cr-crossfade cr-from="pink" cr-to="blue"}
+This is an image with the sticky tag on Image itself.
+
+I've replaced its margin with some padding to demonstrate that you can give it a larger "surface" area on which to trigger scroll events.
 :::
 
 ![](blue-desktop.png){cr-id="blue"}
@@ -34,7 +38,9 @@ Here's a little non-scrolling interlude before our next scrolly section!
 
 ::::{.cr-sidebar}
 
-[This is a scatterplot.]{.cr-crossfade cr-to="scatter"}
+:::{.cr-crossfade cr-to="scatter"}
+This is a scatterplot.
+:::
 
 ```{r}
 #| echo: false
@@ -43,7 +49,9 @@ Here's a little non-scrolling interlude before our next scrolly section!
 plot(mtcars$mpg, mtcars$dist)
 ```
 
-[This is a histogram.]{.cr-crossfade cr-from="scatter" cr-to="hist"}
+:::{.cr-crossfade cr-from="scatter" cr-to="hist"}
+This is a histogram.
+:::
 
 ```{r}
 #| echo: true
@@ -52,14 +60,18 @@ plot(mtcars$mpg, mtcars$dist)
 hist(mtcars$mpg)
 ```
 
-[This is a list (a block element).]{.cr-crossfade cr-from="hist" cr-to="list"}
+:::{.cr-crossfade cr-from="hist" cr-to="list"}
+This is a list (a block element).
+:::
 
 :::{cr-id="list"}
 1. Apple
 2. Banana
 :::
 
-[This is display math.]{.cr-crossfade cr-from="list" cr-to="displaymath"}
+:::{.cr-crossfade cr-from="list" cr-to="displaymath"}
+This is display math, but I'm making it a bit longer so that it covers a few lines.
+:::
 
 ::: {cr-id="displaymath"}
 
@@ -72,13 +84,17 @@ $$
 
 :::
 
-[This is a Para featuring a poem.]{.cr-crossfade cr-from="displaymath" cr-to="oneline"}
+:::{.cr-crossfade cr-from="displaymath" cr-to="oneline"}
+This is a Para featuring a poem.
+:::
 
 ::: {cr-id="oneline"}
 One hen, two ducks ...
 :::
 
-[This is a mermaid diagram]{.cr-crossfade cr-from="oneline" cr-to="mermaid"}
+:::{.cr-crossfade cr-from="oneline" cr-to="mermaid"}
+This is a mermaid diagram
+:::
 
 ```{mermaid}
 %%| cr-id: mermaid
@@ -89,7 +105,9 @@ flowchart LR
   C --> E[Result two]
 ```
 
-[This is a graphviz diagram]{.cr-crossfade cr-from="mermaid" cr-to="graphviz"}
+:::{.cr-crossfade cr-from="mermaid" cr-to="graphviz"}
+This is a graphviz diagram
+:::
 
 ```{dot}
 //| cr-id: graphviz

--- a/sidebar-cr-multiple-block-types.qmd
+++ b/sidebar-cr-multiple-block-types.qmd
@@ -1,7 +1,7 @@
 ---
 format:
   closeread-html:
-    debug-mode: false
+    debug-mode: true
 ---
 
 ::::{.cr-sidebar}
@@ -28,7 +28,7 @@ This is an image with the sticky tag on Image itself.
 I've replaced its margin with some padding to demonstrate that you can give it a larger "surface" area on which to trigger scroll events.
 :::
 
-![](blue-desktop.png){cr-id="blue"}
+![This is a caption](blue-desktop.png){cr-id="blue"}
 
 ::::
 
@@ -56,6 +56,8 @@ This is a histogram.
 ```{r}
 #| echo: true
 #| cr-id: hist
+#| fig-cap: "This is a caption."
+#| fig-height: 4
 
 hist(mtcars$mpg)
 ```

--- a/sidebar-cr-multiple-block-types.qmd
+++ b/sidebar-cr-multiple-block-types.qmd
@@ -19,7 +19,7 @@ This is an image with the sticky tag on the div.
 :::
 
 :::{cr-id="pink"}
-![](pink-desktop.png)
+![This is a caption](pink-desktop.png)
 :::
 
 :::{.cr-crossfade cr-from="pink" cr-to="blue"}


### PR DESCRIPTION
This PR adds two things:

## 1. Wrap steps

Narrative blocks that are also steps/triggers (currently defined by `.crossfade`) are wrapped in divs, and any CR-related classes or attributes get moved to the parent div.

This solves a few problems related to sizing and fast scrolls: previously, steps that only took up one line of text weren't triggering properly at narrower screen widths (even if they were completely visible), and when a fast scroll ended inside a sidebar section but not with any particular step intersecting the offset line, the sticky wouldn't update. Now that steps take up more room on either side, they're a lot more resilient to fast scrolls and small step content (although not entirely resilient to the former: a quick scroll that ends in an interlude may still fail to trigger an update below).

There's one big user change with this: it doesn't work with spans. All steps have to be blocks. We could probably write extra logic into the Lua to handle spans, but it would still be assuming that we're only talking about spans that take up their entire parent `<p>` (ie. that a Quarto user is just writing a par wrapped in a span). Would love to hear your thoughts too, @andrewpbray, but my feeling is that it's just easier to tell the user to use divs and forget the span syntax altogether for spans.

The other downside to this is that blocks trigger a bit early now (see point 2 below to visualise!), as we have padding both above and below them. There're a few ways around that:

1. Adjust the offset to taste (say, make it trigger at 25% from the top rather than at 50%).
2. Offset in scrollama terms refer to the fraction of the screen height at which an element intersection triggers an update. But separately, we also track 'progress' (fraction of the element's height that has passed the offset). We could build progress in too, so that typical updates only happen when, say, 30% of the triggering element has progressed past the offset).

## 2. Debugging styles

I've also attached a `.cr-debug` class to our sidebars when Scrollama's debug mode is on, and added some styles for our steps so that it is easier to see the intersections happening!